### PR TITLE
Use trusty as the base for 4.6 and 4.7

### DIFF
--- a/gcc-4.6/Dockerfile
+++ b/gcc-4.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:precise
+FROM ubuntu:trusty
 MAINTAINER Thomas Kent <teeks99@yahoo.com>
 
 # Enable future toolchain PPA

--- a/gcc-4.7/Dockerfile
+++ b/gcc-4.7/Dockerfile
@@ -1,10 +1,9 @@
-FROM ubuntu:precise
+FROM ubuntu:trusty
 MAINTAINER Thomas Kent <teeks99@yahoo.com>
 
 # Enable future toolchain PPA
 RUN apt-get update \
  && apt-get install -y python-software-properties \
- && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
 
 # Install pre-reqs
  && apt-get update \


### PR DESCRIPTION
Add gcc-4.8 to both for additional build tools